### PR TITLE
Reties With not empty URL Path

### DIFF
--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -327,6 +327,8 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			}
 		}
 	}
+	
+	originalPath := req.URL.Path
 
 	for i := 0; i <= c.maxRetries; i++ {
 		var (
@@ -422,6 +424,8 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		if !shouldRetry {
 			break
 		}
+		
+		req.URL.Path = originalPath
 
 		// Drain and close body when retrying after response
 		if shouldCloseBody && i < c.maxRetries {


### PR DESCRIPTION
transport builds an incorrect request path if the address is configured with a path, for example:

```
	eCnf := elasticsearch.Config{
		Addresses: []string{
			"https://server.com/somepath"
		},
	}
``` 
it happens when retries is enabled and the API returns an error, transports adds to the request "/somepath" on each retry instead of building a new path.